### PR TITLE
Feature: show relevant user info on account settings and profile pages

### DIFF
--- a/client/components/Account/index.js
+++ b/client/components/Account/index.js
@@ -1,6 +1,7 @@
 var template = require('./template.ejs');
 var emitter = require('component-emitter');
 var ui = require('georap-ui');
+var account = georap.stores.account;
 var themeStore = georap.stores.theme;
 var localesStore = georap.stores.locales;
 var availableLocales = georap.config.availableLocales;
@@ -19,8 +20,11 @@ module.exports = function () {
   // Public methods
 
   this.bind = function ($mount) {
+    var user = account.getUser();
     $mount.html(template({
       theme: themeStore.get(),
+      username: user.name,
+      email: user.email,
       currentLocale: localesStore.getLocale(),
       availableLocales: availableLocales,
       __: georap.i18n.__,

--- a/client/components/Account/index.js
+++ b/client/components/Account/index.js
@@ -33,12 +33,17 @@ module.exports = function () {
     colorSchemes.forEach(function (colorScheme, i) {
       var elemid = 'theme-' + colorScheme;
       $elems[elemid] = $('#' + elemid);
-      $elems[elemid].on('change', function () {
+      $elems[elemid].click(ui.throttle(1000, function (ev) {
+        // No navigation
+        ev.preventDefault();
+        // Switch theme dynamically
         themeStore.update({
           colorScheme: colorScheme,
           themeColor: themeColors[i],
         });
-      });
+        // Hacky but simple way to refresh selection-star
+        $mount.find('.color-schemes .glyphicon-star').appendTo($elems[elemid]);
+      }));
     });
   };
 

--- a/client/components/Account/template.ejs
+++ b/client/components/Account/template.ejs
@@ -31,13 +31,16 @@
 
       <div class="list-group">
         <% availableLocales.forEach(function (locale) { %>
-          <% var activity = locale === currentLocale ? 'active' : '' %>
+          <% var isActive = locale === currentLocale %>
           <a href="?locale=<%= locale %>"
-             class="list-group-item <%= activity %>"
+             class="list-group-item"
              lang="<%= locale %>"
              target="_self">
             <% // target=_self is necessary to bypass page.js router %>
             <%= __('locale-native', locale) %>
+            <% if (isActive) { %>
+              <span class="glyphicon glyphicon-star" aria-label="selected"></span>
+            <% } %>
           </a>
         <% }) %>
       </div>

--- a/client/components/Account/template.ejs
+++ b/client/components/Account/template.ejs
@@ -11,22 +11,30 @@
       <h3><%= __('security') %></h3>
       <p><a class="btn btn-default" href="/account/email" role="button"><span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> <%= __('change-email') %>...</a></p>
       <p><a class="btn btn-default" href="/account/password" role="button"><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span> <%= __('change-password') %>...</a></p>
-
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-5">
       <h3><%= __('theme') %></h3>
 
-      <div class="radio">
-        <label>
-          <input type="radio" name="colorScheme" id="theme-light" value="light" <%= theme.colorScheme === 'light' ? 'checked' : '' %>>
+      <div class="color-schemes list-group">
+        <a href="#" class="list-group-item" id="theme-light">
           <%= __('theme-light') %>
-        </label>
-      </div>
-      <div class="radio">
-        <label>
-          <input type="radio" name="colorScheme" id="theme-dark" value="dark" <%= theme.colorScheme === 'dark' ? 'checked' : '' %>>
+          <% if (theme.colorScheme === 'light') { %>
+            <span class="glyphicon glyphicon-star" aria-label="selected"></span>
+          <% } %>
+        </a>
+        <a href="#" class="list-group-item" id="theme-dark">
           <%= __('theme-dark') %>
-        </label>
+          <% if (theme.colorScheme === 'dark') { %>
+            <span class="glyphicon glyphicon-star" aria-label="selected"></span>
+          <% } %>
+        </a>
       </div>
-
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-5">
       <h3><%= __('language') %></h3>
 
       <div class="list-group">

--- a/client/components/Account/template.ejs
+++ b/client/components/Account/template.ejs
@@ -3,6 +3,11 @@
     <div class="col-md-12">
       <h1><span class="glyphicon glyphicon-user" aria-hidden="true"></span> <%= __('account-settings') %></h1>
 
+      <p>
+        <%= __('username') %>: <%= username %><br>
+        <%= __('email') %>: <%= email %>
+      </p>
+
       <h3><%= __('security') %></h3>
       <p><a class="btn btn-default" href="/account/email" role="button"><span class="glyphicon glyphicon-envelope" aria-hidden="true"></span> <%= __('change-email') %>...</a></p>
       <p><a class="btn btn-default" href="/account/password" role="button"><span class="glyphicon glyphicon-asterisk" aria-hidden="true"></span> <%= __('change-password') %>...</a></p>

--- a/client/components/User/index.js
+++ b/client/components/User/index.js
@@ -41,6 +41,7 @@ module.exports = function (username) {
 
       // User statistics
       $('#georap-user-points').html(pointsTemplate({
+        createdAt: ui.timestamp(user.createdAt, georap.i18n.locale),
         flagConfig: flagConfig,
         flags: user.flagsCreated,
         adds: user.locationsCreated,

--- a/client/components/User/index.js
+++ b/client/components/User/index.js
@@ -48,7 +48,6 @@ module.exports = function (username) {
         posts: user.postsCreated,
         classifications: user.locationsClassified,
         comments: user.commentsCreated,
-        points: user.points,
         __: __,
       }));
 

--- a/client/components/User/points.ejs
+++ b/client/components/User/points.ejs
@@ -1,3 +1,4 @@
+<h3><span class="glyphicon glyphicon-time" aria-hidden="true"></span> <%= __('user-joined') %> <%= createdAt %></h3>
 <% flags.forEach(function (flag) { %>
 <h3><span class="glyphicon glyphicon-<%= flagConfig[flag.name].glyphicon %>" aria-hidden="true"></span> <%= flag.count %> <%= __(flagConfig[flag.name].plural) %></h3>
 <% }) %>

--- a/client/components/User/points.ejs
+++ b/client/components/User/points.ejs
@@ -6,8 +6,3 @@
 <h3><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> <%= posts %> <%= __('posts-count') %></h3>
 <h3><span class="glyphicon glyphicon-tags" aria-hidden="true"></span> <%= classifications %> <%= __('tags-count') %></h3>
 <h3><span class="glyphicon glyphicon-comment" aria-hidden="true"></span> <%= comments %> <%= __('comments-count') %></h3>
-
-<div class="points-equality-line"></div>
-
-<h3>= <%= points %> <span class="glyphicon glyphicon-star" aria-hidden="false"></span></h3>
-<p><%= __('points-updated-hourly') %></p>

--- a/client/components/User/template.ejs
+++ b/client/components/User/template.ejs
@@ -14,7 +14,7 @@
 
       <div id="georap-user-points" style="margin-top: 1.62em"></div>
 
-      <div style="margin-top: 1.62em">
+      <div style="margin-top: 2.62em">
         <h3><%= __('event-log') %></h3>
         <div id="georap-user-events"></div>
       </div>

--- a/client/themes/base.css
+++ b/client/themes/base.css
@@ -19,7 +19,7 @@ html, body {
   -webkit-transform: scale(-1, 1);
   transform: scale(-1, 1);
 }
-time {
+time:hover {
   text-decoration: underline;
 }
 .georap-disabled {


### PR DESCRIPTION
New features:
- show username and email on account settings page
- show how long ago user joined on user profile page

Minor changes:
- show underline on timestamps only on mouse hover
- to damp competitiveness a bit, do not list total points on user profile page
